### PR TITLE
Fix leftover 'Compiler' occurrences by renaming to 'Sass'

### DIFF
--- a/spec/sass_compiler_spec.cr
+++ b/spec/sass_compiler_spec.cr
@@ -14,6 +14,12 @@ private SIMPLE_CSS    = <<-'CSS'
 describe "Sass" do
   describe "#compile" do
     it "compiles simple scss" do
+      Sass.new.compile(%(body { div { color: red }})).should eq "body div {\n  color: red; }\n"
+    end
+  end
+
+  describe ".compile" do
+    it "compiles simple scss" do
       Sass.compile(%(body { div { color: red }})).should eq "body div {\n  color: red; }\n"
     end
 
@@ -52,6 +58,12 @@ describe "Sass" do
   end
 
   describe "#compile_file" do
+    it "compiles simple scss file" do
+      Sass.new.compile_file(File.join(INCLUDES_PATH, "_simple.scss")).should eq SIMPLE_CSS
+    end
+  end
+
+  describe ".compile_file" do
     it "compiles simple scss file" do
       Sass.compile_file(File.join(INCLUDES_PATH, "_simple.scss")).should eq SIMPLE_CSS
     end

--- a/src/compiler.cr
+++ b/src/compiler.cr
@@ -109,7 +109,7 @@ class Sass
   #
   # For available options see class description.
   def compile(string)
-    Compiler.compile(string, **options)
+    Sass.compile(string, **options)
   end
 
   # :nodoc:
@@ -141,7 +141,7 @@ class Sass
   #
   # For available options see class description.
   def compile_file(file)
-    Compiler.compile_file(file, **options)
+    Sass.compile_file(file, **options)
   end
 
   # :nodoc:

--- a/src/sass.cr
+++ b/src/sass.cr
@@ -8,20 +8,6 @@ class Sass
   def self.libsass_version
     String.new(LibSass.libsass_version)
   end
-
-  # Compiles a Sass/SCSS string and returns CSS as `String`.
-  #
-  # For available options see `Sass::Options`.
-  def self.compile(string, **options)
-    Compiler.compile(string, **options)
-  end
-
-  # Compiles a Sass/SCSS file and returns CSS as `String`.
-  #
-  # For available options see `Sass::Options`.
-  def self.compile_file(file, **options)
-    Compiler.compile_file(file, **options)
-  end
 end
 
 require "./lib_sass"


### PR DESCRIPTION
Not 100% sure that this is correct, but it works for me.
Without this change i get:

```
In lib/sass/src/compiler.cr:144:5

 144 | Compiler.compile_file(file, **options)
       ^-------
Error: undefined constant Compiler
```