### PR TITLE
Add pkg-config name to Link annotation

### DIFF
--- a/src/lib_sass.cr
+++ b/src/lib_sass.cr
@@ -1,5 +1,5 @@
 # Bindings to `libsass`
-@[Link("sass")]
+@[Link("sass", pkg_config: "libsass")]
 lib LibSass
   alias Char = LibC::Char
 


### PR DESCRIPTION
I noticed that the shard failed to link on macOS with Homebrew:
https://github.com/ysbaddaden/test-ecosystem/actions/runs/21253918730/job/61162901116

I'm not sure it will fix the issue, but at least crystal shall be able to use pkg-config to tell the linker where to find the lib.